### PR TITLE
Surface files configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,26 +47,72 @@ pip3 install whispers
 
 ### CLI
 
-```
+```bash
+# General usage & help
 whispers
+
+# More information about Whispers
+whispers --info
+```
+
+```bash
+# Simplest usage with JSON output
 whispers dir/or/file
 
-whispers --help
-whispers --info
+# Simplest usage with human-readable output
+whispers -H dir/or/file
+
+# Write results to a file instead of the screen
+whispers -o /tmp/secrets.json dir/or/file
+
+# Advanced usage:
+#   - only check 'keys' rule group
+#   - with BLOCKER or CRITICAL severity
+#   - everywhere in target/dir except for .log & .raw files
+whispers -g keys -s BLOCKER,CRITICAL -F '.*\.(log|raw)' target/dir
+```
+
+```bash
+# Configuration file template
 whispers --print_config > config.yml
 
+# Provide custom configuration file
 whispers --config config.yml dir/or/file
-whispers --output /tmp/secrets.out dir/or/file
+
+# Return this system code on success
 whispers --exitcode 7 dir/or/file
+```
 
+```bash
+# Include only 'aws-id' & 'aws-secret' rule IDs
 whispers --rules aws-id,aws-secret dir/or/file
+
+# Exclude 'file-known' rule ID
 whispers --xrules file-known dir/or/file
+```
 
+```bash
+# Include only 'keys' & 'misc' rule groups
 whispers --groups keys,misc dir/or/file
-whispers --xgroups files dir/or/file
 
+# Exclude 'files' rule group
+whispers --xgroups files dir/or/file
+```
+
+```bash
+# Include only BLOCKER & CRITICAL severity
 whispers --severity BLOCKER,CRITICAL dir/or/file
+
+# Exclude all MINOR severity
 whispers --xseverity MINOR dir/or/file
+```
+
+```bash
+# Include only .json & .yml files
+whispers --files '*.json,*.yml' dir/or/file
+
+# Exclude .log & .cfg files
+whispers --xfiles '.*\.(log|cfg)' dir/or/file
 ```
 
 

--- a/tests/unit/core/test_args.py
+++ b/tests/unit/core/test_args.py
@@ -1,6 +1,7 @@
 from argparse import ArgumentParser
 from io import StringIO, TextIOWrapper
 from os import remove, urandom
+from re import compile
 from sys import stdout
 from unittest.mock import patch
 
@@ -18,8 +19,9 @@ def test_argument_parser():
 @pytest.mark.parametrize(
     ("arguments", "key", "expected", "exception"),
     [
-        (["target"], "src", "target", does_not_raise()),
-        (["target"], "output", stdout, does_not_raise()),
+        (["src"], "src", "src", does_not_raise()),
+        (["src"], "output", stdout, does_not_raise()),
+        (["-H", "src"], "human", True, does_not_raise()),
         (
             ["-c", config_path("detection_by_value.yml"), "src"],
             "config",
@@ -29,6 +31,8 @@ def test_argument_parser():
         (["-r", "rule-1,rule-2", "src"], "rules", ["rule-1", "rule-2"], does_not_raise()),
         (["-e", "123", "src"], "exitcode", 123, does_not_raise()),
         (["-s", "a,b,c", "src"], "severity", ["a", "b", "c"], does_not_raise()),
+        (["-f", "*.json", "src"], "files", ["*.json"], does_not_raise()),
+        (["-F", ".*\\.(yml|json)", "src"], "xfiles", compile(r".*\.(yml|json)"), does_not_raise()),
         (["-i"], "info", True, pytest.raises(SystemExit)),
         (["-d"], "debug", True, pytest.raises(SystemExit)),
         (["--print_config"], "print_config", True, pytest.raises(SystemExit)),

--- a/tests/unit/core/test_printer.py
+++ b/tests/unit/core/test_printer.py
@@ -6,7 +6,7 @@ from whispers.core.printer import printer
 from whispers.models.pair import KeyValuePair
 
 
-def test_printer_to_file(tmp_path, rule_fixture):
+def test_printer_json(tmp_path, rule_fixture):
     tmp = tmp_path.joinpath("printer.test")
     args = parse_args(["-o", tmp.as_posix(), fixture_path()])
     pair = KeyValuePair("key", "value", ["root", "key"], "/file", 123, rule_fixture)
@@ -24,8 +24,8 @@ def test_printer_to_file(tmp_path, rule_fixture):
     assert result == expected
 
 
-def test_printer_to_stdout(rule_fixture):
-    args = parse_args([fixture_path()])
+def test_printer_human(rule_fixture):
+    args = parse_args(["-H", fixture_path()])
     pair = KeyValuePair("key", "value", ["root", "key"], "/file", 123, rule_fixture)
     expected = (
         f"[{pair.file}:{pair.line}:{pair.rule.group}:{pair.rule.id}:{pair.rule.severity}]"

--- a/whispers/core/args.py
+++ b/whispers/core/args.py
@@ -1,6 +1,7 @@
 import logging
 from argparse import ArgumentParser, Namespace
 from functools import wraps
+from re import compile
 from sys import argv, stdout
 
 from whispers.__version__ import __version__, __whispers__
@@ -16,7 +17,12 @@ def argument_parser() -> ArgumentParser:
         "-C", "--print_config", default=False, action="store_true", help="print default config and exit"
     )
     args_parser.add_argument("-o", "--output", help="output file")
+    args_parser.add_argument(
+        "-H", "--human", default=False, action="store_true", help="output in human-readable format"
+    )
     args_parser.add_argument("-e", "--exitcode", default=0, type=int, help="exit code on success")
+    args_parser.add_argument("-f", "--files", help="csv of globs for including files")
+    args_parser.add_argument("-F", "--xfiles", help="regex for excluding files")
     args_parser.add_argument("-g", "--groups", help="csv of rule groups to report (see --info)")
     args_parser.add_argument("-G", "--xgroups", help="csv of rule groups to exclude (see --info)")
     args_parser.add_argument("-r", "--rules", help="csv of rule IDs to report (see --info)")
@@ -60,6 +66,12 @@ def parse_args(arguments: list = argv[1:]) -> Namespace:
         args.output = open(args.output, "w")
     else:
         args.output = stdout
+
+    if args.files:
+        args.files = args.files.split(",")
+
+    if args.xfiles:
+        args.xfiles = compile(args.xfiles)
 
     if args.rules:
         args.rules = args.rules.split(",")

--- a/whispers/core/printer.py
+++ b/whispers/core/printer.py
@@ -1,13 +1,12 @@
 import json
 from argparse import Namespace
-from sys import stdout
 
 from whispers.models.pair import KeyValuePair
 
 
 def printer(args: Namespace, pair: KeyValuePair) -> str:
     """Prints formatted pair data to given output"""
-    if args.output is stdout:
+    if args.human:
         fmt = (
             f"[{pair.file}:{pair.line}:{pair.rule.group}:{pair.rule.id}:{pair.rule.severity}]"
             + f" {pair.key} = {pair.value}"

--- a/whispers/core/scope.py
+++ b/whispers/core/scope.py
@@ -1,19 +1,21 @@
 from argparse import Namespace
 from pathlib import Path
-from typing import Iterator
+from typing import Iterable
 
 
-def load_scope(args: Namespace, config: dict) -> Iterator[Path]:
+def load_scope(args: Namespace, config: dict) -> Iterable[Path]:
     """Load a list of files in scope based on args and config"""
+    include_files = args.files or config.include.files
+    exclude_files = args.xfiles or config.exclude.files
     src = Path(args.src)
+
     if src.is_file():
         yield src
 
     else:
-        excluded = config.exclude.files
-        for include in config.include.files:
-            for path in src.rglob(include):
-                if excluded and excluded.match(path.as_posix()):
+        for include in include_files:
+            for filepath in src.rglob(include):
+                if exclude_files and exclude_files.match(filepath.as_posix()):
                     continue
 
-                yield path
+                yield filepath


### PR DESCRIPTION
* Added human-readable format arg `-H`
* Surfaced file include & exclude configuration to args:
  * `whispers -f 'glob1,glob2' target` to only include files that match given globs
  * `whispers -F 'regex' target` to exclude all file paths that match given regex