### PR TITLE
2.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ whispers -o /tmp/secrets.json dir/or/file
 # Advanced usage:
 #   - only check 'keys' rule group
 #   - with BLOCKER or CRITICAL severity
-#   - everywhere in target/dir except for .log & .raw files
+#   - everywhere in target/dir except for .log & .raw files (regex)
 whispers -g keys -s BLOCKER,CRITICAL -F '.*\.(log|raw)' target/dir
 ```
 
@@ -109,10 +109,10 @@ whispers --xseverity MINOR dir/or/file
 ```
 
 ```bash
-# Include only .json & .yml files
+# Include only .json & .yml files (globs)
 whispers --files '*.json,*.yml' dir/or/file
 
-# Exclude .log & .cfg files
+# Exclude .log & .cfg files (regex)
 whispers --xfiles '.*\.(log|cfg)' dir/or/file
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@
 #
 astroid==2.11.3
 beautifulsoup4==4.11.1
-dataclasses==0.6
 jellyfish==0.9.0
 jproperties==2.1.1
 lazy-object-proxy==1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make freeze-upgrade
 #
-astroid==2.11.2
+astroid==2.11.3
 beautifulsoup4==4.11.1
 dataclasses==0.6
 jellyfish==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,10 @@ from sys import version_info
 
 
 install_requires = ["luhn", "lxml", "pyyaml", "astroid", "jproperties", "jellyfish", "beautifulsoup4"]
-if version_info < (3, 7):  # Python 3.6 requirements
-    install_requires.append("dataclasses")
+
+# Python 3.6 requirements
+if version_info < (3, 7):
+    install_requires += ["dataclasses"]
 
 dev_requires = [
     "autoflake~=1.4",

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
 from importlib import import_module
 from setuptools import find_packages, setup
 from pathlib import Path
+from sys import version_info
 
 
-install_requires = ["dataclasses", "luhn", "lxml", "pyyaml", "astroid", "jproperties", "jellyfish", "beautifulsoup4"]
+install_requires = ["luhn", "lxml", "pyyaml", "astroid", "jproperties", "jellyfish", "beautifulsoup4"]
+if version_info < (3, 7):  # Python 3.6 requirements
+    install_requires.append("dataclasses")
 
 dev_requires = [
     "autoflake~=1.4",

--- a/tests/fixtures/.npmrc
+++ b/tests/fixtures/.npmrc
@@ -11,3 +11,5 @@
 //registry.npmjs.org/:_authToken=6c141bb5-5b6d-1311-98dc-hardcoded
 //localhost:4873/:_authToken=U2t5c2Nhbm5lciB3MDAwhardcoded
 //artifactory.jfrog.com/artifactory/api/npm/npm/:_authToken=eyFake1.eyJFake2.Fake3.hardcoded
+//registry.npmjs.org/:_authToken=$ecret
+//registry.npmjs.org/:_authToken=secr€t

--- a/tests/fixtures/hardcoded.json
+++ b/tests/fixtures/hardcoded.json
@@ -1,7 +1,7 @@
 {
   "compliant": {
-    "01_variable_password": "$password",
-    "02_variable_password": "$$password",
+    "01_variable_password": "$PASSWORD",
+    "02_variable_password": "$$PASSWORD",
     "03_variable_password": "${password}",
     "04_variable_password": "${{password}}",
     "05_variable_password": "{{ password }}",

--- a/tests/fixtures/hardcoded.xml
+++ b/tests/fixtures/hardcoded.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <tests>
   <compliant>
-    <o1_variable_password>$password</o1_variable_password>
-    <o2_variable_password>$$password</o2_variable_password>
+    <o1_variable_password>$PASSWORD</o1_variable_password>
+    <o2_variable_password>$$PASSWORD</o2_variable_password>
     <o3_variable_password>${password}</o3_variable_password>
     <o4_variable_password>${{password}}</o4_variable_password>
     <o5_variable_password>{{ password }}</o5_variable_password>

--- a/tests/fixtures/hardcoded.yml
+++ b/tests/fixtures/hardcoded.yml
@@ -1,6 +1,6 @@
 # Compliant
-01_variable_password: $password
-02_variable_password: $$password
+01_variable_password: $PASSWORD
+02_variable_password: $$PASSWORD
 03_variable_password: ${password}
 04_variable_password: ${{password}}
 05_variable_password: "{{ password }}"

--- a/tests/integration/test_whispers.py
+++ b/tests/integration/test_whispers.py
@@ -7,7 +7,7 @@ from tests.unit.conftest import config_path, fixture_path
 @pytest.mark.parametrize(
     ("args", "expected"),
     [
-        (f"-c {config_path('integration.yml')} {fixture_path()}", 3),
+        (f"-c {config_path('integration.yml')} {fixture_path()}", 5),
         (f"-r apikey-known {fixture_path('apikeys-known.yml')}", 54),
         (f"--rules file-known {fixture_path('files')}", 3),
         (f"-s BLOCKER {fixture_path('aws.yml')}", 3),

--- a/tests/unit/core/test_pairs.py
+++ b/tests/unit/core/test_pairs.py
@@ -31,7 +31,7 @@ from whispers.plugins.yml import Yml
         (tmp_path("File.404"), 0),
         (forbidden_path(), 0),
         (fixture_path("language.py2"), 0),
-        (fixture_path(".npmrc"), 3),
+        (fixture_path(".npmrc"), 5),
         (fixture_path("placeholders.xml"), 0),
         (fixture_path("privatekey.pem"), 1),
         (fixture_path("putty.ppk"), 0),

--- a/tests/unit/core/test_secrets.py
+++ b/tests/unit/core/test_secrets.py
@@ -48,7 +48,7 @@ def test_detect_secrets_by_key(src, expected):
         (".aws/credentials", "BLOCKER", 3),
         (".dockercfg", "CRITICAL", 1),
         (".htpasswd", "MAJOR", 2),
-        (".npmrc", "CRITICAL", 3),
+        (".npmrc", "CRITICAL", 5),
         (".pypirc", "CRITICAL", 1),
         ("apikeys-known.yml", "CRITICAL", 54),
         ("apikeys.json", "MAJOR", 9),

--- a/tests/unit/core/test_utils.py
+++ b/tests/unit/core/test_utils.py
@@ -129,7 +129,11 @@ def test_load_yaml_from_file(configfile, expected, raised):
     [
         (None, None, False),
         ("key", "", False),
-        ("key", "$value", False),
+        ("key", "$value", True),
+        ("key", "$$Value", True),
+        ("key", "$VALUE", False),
+        ("key", "${value}", False),
+        ("key", "${VALUE}", False),
         ("key", "{{value}}", False),
         ("key", "{value}", False),
         ("key", "{whispers~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~}", False),

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -13,4 +13,4 @@ def test_cli():
 def test_run():
     args = parse_args([fixture_path()])
     secrets = list(run(args))
-    assert len(secrets) == 305
+    assert len(secrets) == 307

--- a/whispers/__version__.py
+++ b/whispers/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (2, 0, 5)
+VERSION = (2, 0, 6)
 
 __version__ = ".".join(map(str, VERSION))
 

--- a/whispers/core/utils.py
+++ b/whispers/core/utils.py
@@ -20,6 +20,7 @@ REGEX_URI = re.compile(r"[:\w\d]+://.+", flags=re.IGNORECASE)
 REGEX_PATH = re.compile(r"^((([A-Z]|file|root):)?(\.+)?[/\\]+).*$", flags=re.IGNORECASE)
 REGEX_IAC = re.compile(r"\![A-Za-z]+ .+", flags=re.IGNORECASE)
 REGEX_PRIVKEY_FILE = re.compile(r"(rsa|dsa|ed25519|ecdsa|pem|crt|cer|ca-bundle|p7b|p7c|p7s|ppk|pkcs12|pfx|p12)")
+REGEX_ENVVAR = re.compile(r"^\$\$?[A-Z0-9_]+$")
 
 
 def load_regex(regex: str, flags: Optional[re.RegexFlag] = 0) -> Pattern:
@@ -89,7 +90,8 @@ def is_static(key: str, value: str) -> bool:
         return False  # Empty
 
     if value.startswith("$") and "$" not in value[2:]:
-        return False  # Variable
+        if REGEX_ENVVAR.match(value):
+            return False  # Variable
 
     if value.startswith("%") and value.endswith("%"):
         return False  # Variable


### PR DESCRIPTION
* Install `dataclasses` only for Python 3.6 to avoid dependency conflicts with higher versions (Fixes https://github.com/Skyscanner/whispers/issues/107)
* Improve hardcoded secret detection for values starting with `$` (Fixes https://github.com/Skyscanner/whispers/issues/108)